### PR TITLE
Multiple aliases

### DIFF
--- a/hubot/modules/config-helper/config-helper.js
+++ b/hubot/modules/config-helper/config-helper.js
@@ -15,6 +15,7 @@ module.exports = class ConfigHelper {
     this.config = yaml.safeLoad(configyaml) || {};
     this.initConfig(this.config);
 
+    this.customCalls = [];
     this.applyConfigToMethods(methods);
     this.methods = methods;
   }
@@ -42,10 +43,6 @@ module.exports = class ConfigHelper {
           permission = option.allow_default_call;
         }
 
-        if ('alias' in option) {
-          method.alias = option.alias;
-        }
-
         if ('help' in option) {
           method.help = option.help;
         }
@@ -63,6 +60,22 @@ module.exports = class ConfigHelper {
         } else {
           method.defaults = {};
         }
+
+        // this uses other options from the method that should at this point already be set
+        if ('custom_calls' in option) {
+          option.custom_calls.forEach(customCall => {
+            let defaults = customCall.defaults || {};
+            let help = customCall.help || method.help;
+
+            this.customCalls.push({
+              method: method,
+              alias: customCall.alias,
+              defaults: this.applyParametersToDefaults(method.defaults, defaults),
+              help: help,
+            });
+          });
+          method.alias = option.alias;
+        }
       }
 
       method.isDefaultCallAllowed = permission;
@@ -72,19 +85,17 @@ module.exports = class ConfigHelper {
 
   getCustomCalls() {
     let customCalls = [];
-    this.methods.forEach(method => {
-      if (method.alias) {
-        let customCall = {
-          name: method.alias,
-          methodFqn: method.name,
-          // this currently allows parameters to be specified directly after the alias
-          // (without whitespace) -> might leed to clashes between aliases having a common prefix
-          regexp: new RegExp(method.alias + '([\\s\\S]*)', 'i'),
-          methodSplit: method.name.replace('.', '').split('.'),
-          defaultParameters: method.defaults,
-        };
-        customCalls.push(customCall);
-      }
+    this.customCalls.forEach(customCall => {
+      let call = {
+        name: customCall.alias,
+        methodFqn: customCall.method.name,
+        // this currently allows parameters to be specified directly after the alias
+        // (without whitespace) -> might leed to clashes between aliases having a common prefix
+        regexp: new RegExp(customCall.alias + '([\\s\\S]*)', 'i'),
+        methodSplit: customCall.method.name.replace('.', '').split('.'),
+        defaultParameters: customCall.defaults,
+      };
+      customCalls.push(call);
     });
     return customCalls;
   }
@@ -116,16 +127,17 @@ module.exports = class ConfigHelper {
     return {};
   }
 
-  applyUserParametersToDefaults(defaultParameters, userParameters) {
+  applyParametersToDefaults(defaultParameters, overrideParameters) {
     // Create a deep copy of the object
     // (not sure if this is the best way but its also done by others)
-    let parameters = JSON.parse(JSON.stringify(defaultParameters));
+    defaultParameters = JSON.parse(JSON.stringify(defaultParameters));
+    overrideParameters = JSON.parse(JSON.stringify(overrideParameters));
     // Override default parameters with user parameters
-    for (var key in userParameters) {
-      parameters[key] = userParameters[key];
+    for (var key in overrideParameters) {
+      defaultParameters[key] = overrideParameters[key];
     }
 
-    return parameters;
+    return defaultParameters;
   }
 
   getResponseTemplates(methodFqn) {
@@ -142,14 +154,6 @@ module.exports = class ConfigHelper {
     let commands = [];
 
     this.methods.forEach(method => {
-
-      // If there is an alias defined: Output command using alias
-      if (method.alias) {
-        // Mighty Template String for alias commands
-        let aliasCommand = `${method.alias} ${method.parameters.map(param =>
-          `<${param.name}:${param.type}${param.repeated ? '[]' : ''}>`).join(' ')}${method.help ? ` - ${method.help}` : ''}`.trim();
-        commands.push(aliasCommand);
-      }
       // If the default call is allowed: Output default command
       if (method.isDefaultCallAllowed) {
         // Mighty Template String for default commands
@@ -157,7 +161,13 @@ module.exports = class ConfigHelper {
           `<${param.name}:${param.type}${param.repeated ? '[]' : ''}>`).join(' ')}${method.help ? ` - ${method.help}` : ''}`.trim();
         commands.push(defaultCommand);
       }
+    });
 
+    this.customCalls.forEach(customCall => {
+      // Mighty Template String for alias commands
+      let aliasCommand = `${customCall.alias} ${customCall.method.parameters.map(param =>
+        `<${param.name}:${param.type}${param.repeated ? '[]' : ''}>`).join(' ')}${customCall.help ? ` - ${customCall.help}` : ''}`.trim();
+      commands.push(aliasCommand);
     });
 
     return commands;

--- a/hubot/modules/config-helper/config-helper.js
+++ b/hubot/modules/config-helper/config-helper.js
@@ -93,7 +93,7 @@ module.exports = class ConfigHelper {
         // (without whitespace) -> might leed to clashes between aliases having a common prefix
         regexp: new RegExp(customCall.alias + '([\\s\\S]*)', 'i'),
         methodSplit: customCall.method.name.replace('.', '').split('.'),
-        defaultParameters: customCall.defaults,
+        defaults: customCall.defaults,
       };
       customCalls.push(call);
     });

--- a/hubot/modules/config-helper/config-helper.js
+++ b/hubot/modules/config-helper/config-helper.js
@@ -70,22 +70,23 @@ module.exports = class ConfigHelper {
     });
   }
 
-  getAliases() {
-    let aliases = [];
+  getCustomCalls() {
+    let customCalls = [];
     this.methods.forEach(method => {
       if (method.alias) {
-        let alias = {
+        let customCall = {
           name: method.alias,
           methodFqn: method.name,
           // this currently allows parameters to be specified directly after the alias
           // (without whitespace) -> might leed to clashes between aliases having a common prefix
           regexp: new RegExp(method.alias + '([\\s\\S]*)', 'i'),
           methodSplit: method.name.replace('.', '').split('.'),
+          defaultParameters: method.defaults,
         };
-        aliases.push(alias);
+        customCalls.push(customCall);
       }
     });
-    return aliases;
+    return customCalls;
   }
 
   findMethodByFqn(methodFqn) {
@@ -115,10 +116,10 @@ module.exports = class ConfigHelper {
     return {};
   }
 
-  applyUserParametersToDefaults(methodFqn, userParameters) {
+  applyUserParametersToDefaults(defaultParameters, userParameters) {
     // Create a deep copy of the object
     // (not sure if this is the best way but its also done by others)
-    let parameters = JSON.parse(JSON.stringify(this.getDefaultParameters(methodFqn)));
+    let parameters = JSON.parse(JSON.stringify(defaultParameters));
     // Override default parameters with user parameters
     for (var key in userParameters) {
       parameters[key] = userParameters[key];

--- a/hubot/modules/config-helper/test/config-helper_aliases.js
+++ b/hubot/modules/config-helper/test/config-helper_aliases.js
@@ -23,35 +23,35 @@ describe('Getting alias information:', () => {
 
   describe('Aliases:', () => {
 
-    let aliases;
+    let customCalls;
 
     it('does not throw when getting the aliases', () => {
-      let closure = () => { aliases = configHelper.getAliases(); };
+      let closure = () => { customCalls = configHelper.getCustomCalls(); };
 
       expect(closure).not.to.throw();
     });
 
     it('returns three aliases', () => {
-      expect(aliases).to.be.an('array').of.length(3);
+      expect(customCalls).to.be.an('array').of.length(3);
     });
 
     it('gives the correct first alias', () => {
-      expect(aliases[0]).to.have.property('name', 'first');
+      expect(customCalls[0]).to.have.property('name', 'first');
     });
 
     it('has the right method description', () => {
-      expect(aliases[0]).to.have.property('methodFqn', '.pkg.test.first');
-      expect(aliases[0]).to.have.property('methodSplit');
-      expect(aliases[0].methodSplit).to.eql(['pkg', 'test', 'first']);
+      expect(customCalls[0]).to.have.property('methodFqn', '.pkg.test.first');
+      expect(customCalls[0]).to.have.property('methodSplit');
+      expect(customCalls[0].methodSplit).to.eql(['pkg', 'test', 'first']);
     });
 
     it('matches the expected string for the first alias', () => {
-      let match = aliases[0].regexp.exec('first some:{param:false}');
+      let match = customCalls[0].regexp.exec('first some:{param:false}');
       expect(match[1].trim()).to.equal('some:{param:false}');
     });
 
     it('matches the expected string for the second alias', () => {
-      let match = aliases[1].regexp.exec('do second some:{param:[false]}');
+      let match = customCalls[1].regexp.exec('do second some:{param:[false]}');
       expect(match[1].trim()).to.equal('some:{param:[false]}');
     });
   });

--- a/hubot/modules/config-helper/test/config-helper_custom-commands.js
+++ b/hubot/modules/config-helper/test/config-helper_custom-commands.js
@@ -36,19 +36,19 @@ describe('Customized Commands:', () => {
     });
 
     it('gives the correct first command', () => {
-      expect(commands[0]).to.equal('first');
+      expect(commands[0]).to.equal('call .pkg.test.third <text:string> - Calls third and returns nothing');
     });
 
     it('gives the correct second command', () => {
-      expect(commands[1]).to.equal('do second <first:Simple> <second:Simple>');
+      expect(commands[1]).to.equal('first  - Help message for the first alias');
     });
 
     it('gives the correct third command', () => {
-      expect(commands[2]).to.equal('third <text:string> - Calls third and returns nothing');
+      expect(commands[2]).to.equal('do second <first:Simple> <second:Simple>');
     });
 
     it('gives the correct forth command', () => {
-      expect(commands[3]).to.equal('call .pkg.test.third <text:string> - Calls third and returns nothing');
+      expect(commands[3]).to.equal('third <text:string> - Calls third and returns nothing');
     });
   });
 

--- a/hubot/modules/config-helper/test/config-helper_default-params.js
+++ b/hubot/modules/config-helper/test/config-helper_default-params.js
@@ -24,7 +24,7 @@ describe('Default parameters:', () => {
   describe('No defaults specified', () => {
     it('returns the user parameters', () => {
       let params = { text: 'string' };
-      expect(configHelper.applyUserParametersToDefaults(
+      expect(configHelper.applyParametersToDefaults(
         configHelper.getDefaultParameters('pkg.test.third'),
         params
       )).to.eql(params);
@@ -39,7 +39,7 @@ describe('Default parameters:', () => {
     });
 
     it('Correctly merges with user parameters', () => {
-      expect(configHelper.applyUserParametersToDefaults(
+      expect(configHelper.applyParametersToDefaults(
         configHelper.getDefaultParameters('.pkg.test.second'),
         { second: { text: 'second' } }
       )).to.eql(
@@ -51,7 +51,7 @@ describe('Default parameters:', () => {
     });
 
     it('Correctly overrides with user parameters', () => {
-      expect(configHelper.applyUserParametersToDefaults(
+      expect(configHelper.applyParametersToDefaults(
         configHelper.getDefaultParameters('.pkg.test.second'),
         {
           first: { text: 'different' },
@@ -74,7 +74,7 @@ describe('Default parameters:', () => {
     });
 
     it('Correctly applies the default parameters', () => {
-      expect(configHelper.applyUserParametersToDefaults(
+      expect(configHelper.applyParametersToDefaults(
         configHelper.getDefaultParameters('.pkg.test.fourth'),
         {}
       )).to.eql(
@@ -83,13 +83,29 @@ describe('Default parameters:', () => {
     });
 
     it('Correctly overrides with user parameters', () => {
-      expect(configHelper.applyUserParametersToDefaults(
+      expect(configHelper.applyParametersToDefaults(
         configHelper.getDefaultParameters('.pkg.test.fourth'),
         {
           integers: [4, 5, 6],
         }
       )).to.eql(
         { integers: [4, 5, 6] }
+      );
+    });
+  });
+
+  describe('Custom Calls:', () => {
+    it('Reads out the overwritten parameters', () => {
+      let customCall = configHelper.customCalls.find(call => call.alias === 'fourth');
+      expect(customCall.defaults).to.eql(
+        { integers: [2, 3, 4] }
+      );
+    });
+
+    it('Reads out the inherited default parameters', () => {
+      let customCall = configHelper.customCalls.find(call => call.alias === 'default');
+      expect(customCall.defaults).to.eql(
+        { integers: [1, 2, 3] }
       );
     });
   });

--- a/hubot/modules/config-helper/test/config-helper_default-params.js
+++ b/hubot/modules/config-helper/test/config-helper_default-params.js
@@ -24,7 +24,10 @@ describe('Default parameters:', () => {
   describe('No defaults specified', () => {
     it('returns the user parameters', () => {
       let params = { text: 'string' };
-      expect(configHelper.applyUserParametersToDefaults('pkg.test.third', params)).to.eql(params);
+      expect(configHelper.applyUserParametersToDefaults(
+        configHelper.getDefaultParameters('pkg.test.third'),
+        params
+      )).to.eql(params);
     });
   });
 
@@ -37,7 +40,7 @@ describe('Default parameters:', () => {
 
     it('Correctly merges with user parameters', () => {
       expect(configHelper.applyUserParametersToDefaults(
-        '.pkg.test.second',
+        configHelper.getDefaultParameters('.pkg.test.second'),
         { second: { text: 'second' } }
       )).to.eql(
         {
@@ -49,7 +52,7 @@ describe('Default parameters:', () => {
 
     it('Correctly overrides with user parameters', () => {
       expect(configHelper.applyUserParametersToDefaults(
-        '.pkg.test.second',
+        configHelper.getDefaultParameters('.pkg.test.second'),
         {
           first: { text: 'different' },
           second: { text: 'second' },
@@ -71,14 +74,17 @@ describe('Default parameters:', () => {
     });
 
     it('Correctly applies the default parameters', () => {
-      expect(configHelper.applyUserParametersToDefaults('.pkg.test.fourth', {})).to.eql(
+      expect(configHelper.applyUserParametersToDefaults(
+        configHelper.getDefaultParameters('.pkg.test.fourth'),
+        {}
+      )).to.eql(
         { integers: [1, 2, 3] }
       );
     });
 
     it('Correctly overrides with user parameters', () => {
       expect(configHelper.applyUserParametersToDefaults(
-        '.pkg.test.fourth',
+        configHelper.getDefaultParameters('.pkg.test.fourth'),
         {
           integers: [4, 5, 6],
         }

--- a/hubot/modules/config-helper/test/custom-commands.yml
+++ b/hubot/modules/config-helper/test/custom-commands.yml
@@ -2,10 +2,15 @@ allow_default_calls: false
 
 procedure_options:
   - procedure: .pkg.test.first
-    alias: "first"
+    help: "Default call help"
+    custom_calls:
+      - alias: first
+        help: "Help message for the first alias"
   - procedure: .pkg.test.second
-    alias: "do second"
+    custom_calls:
+      - alias: "do second"
   - procedure: .pkg.test.third
     help: "Calls third and returns nothing"
-    alias: "third"
+    custom_calls:
+      - alias: "third"
     allow_default_call: true

--- a/hubot/modules/config-helper/test/default-params.yml
+++ b/hubot/modules/config-helper/test/default-params.yml
@@ -3,6 +3,11 @@ procedure_options:
     defaults:
       first: { "text": "first" }
   - procedure: .pkg.test.fourth
+    custom_calls:
+      - alias: "fourth"
+        defaults:
+          integers: [2,3,4]
+      - alias: "default"
     defaults:
       integers:
         - 1

--- a/hubot/scripts/cloud.coffee
+++ b/hubot/scripts/cloud.coffee
@@ -65,11 +65,9 @@ installCustomCallHandler = (robot, customCall) ->
         fqn: customCall.methodFqn,
         parameters: params,
       }
-      console.log(customCall)
       makeCall response, normalizedCall, customCall.defaults
     catch err
-      console.log err
-      #response.send "Cannot parse your call (line: #{err.location.start.line}, column: #{err.location.start.column}): #{err.message}"
+      response.send "Cannot parse your call (line: #{err.location.start.line}, column: #{err.location.start.column}): #{err.message}"
 
 
 # Configures the plugin
@@ -77,7 +75,7 @@ module.exports = (robot) ->
 
   # Add help commands
   for command in configHelper.getCommands()
-    robot.commands.push "*#{robot.name} #{command}*"
+    robot.commands.push "#{robot.name} #{command}"
 
   # Add listeners for custom aliases
   for customCall in configHelper.getCustomCalls()

--- a/hubot/scripts/cloud.coffee
+++ b/hubot/scripts/cloud.coffee
@@ -65,9 +65,11 @@ installCustomCallHandler = (robot, customCall) ->
         fqn: customCall.methodFqn,
         parameters: params,
       }
+      console.log(customCall)
       makeCall response, normalizedCall, customCall.defaults
     catch err
-      response.send "Cannot parse your call (line: #{err.location.start.line}, column: #{err.location.start.column}): #{err.message}"
+      console.log err
+      #response.send "Cannot parse your call (line: #{err.location.start.line}, column: #{err.location.start.column}): #{err.message}"
 
 
 # Configures the plugin

--- a/hubot/scripts/cloud.coffee
+++ b/hubot/scripts/cloud.coffee
@@ -32,7 +32,7 @@ makeCall = (response, normalizedCall, defaultParameters) ->
     return
 
   # merge params with default params from config
-  normalizedCall.parameters = configHelper.applyUserParametersToDefaults(defaultParameters, normalizedCall.parameters)
+  normalizedCall.parameters = configHelper.applyParametersToDefaults(defaultParameters, normalizedCall.parameters)
   try
     protoHelper.validateCall({
       fqn: normalizedCall.fqn,
@@ -65,7 +65,7 @@ installCustomCallHandler = (robot, customCall) ->
         fqn: customCall.methodFqn,
         parameters: params,
       }
-      makeCall response, normalizedCall, customCall.defaultParameters
+      makeCall response, normalizedCall, customCall.defaults
     catch err
       response.send "Cannot parse your call (line: #{err.location.start.line}, column: #{err.location.start.column}): #{err.message}"
 

--- a/hubot/scripts/cloud.coffee
+++ b/hubot/scripts/cloud.coffee
@@ -25,14 +25,14 @@ caller        = new Caller       protopath, host
 protoHelper   = new ProtoHelper  protopath
 configHelper  = new ConfigHelper configpath, protoHelper.getAllMethods()
 
-makeCall = (response, normalizedCall) ->
+makeCall = (response, normalizedCall, defaultParameters) ->
   # Check if the user is allowed to call this method
   if(!configHelper.isUserAllowed(normalizedCall.fqn, response.message.user.name))
     response.send "You are not allowed to do this"
     return
 
   # merge params with default params from config
-  normalizedCall.parameters = configHelper.applyUserParametersToDefaults(normalizedCall.fqn, normalizedCall.parameters)
+  normalizedCall.parameters = configHelper.applyUserParametersToDefaults(defaultParameters, normalizedCall.parameters)
   try
     protoHelper.validateCall({
       fqn: normalizedCall.fqn,
@@ -53,19 +53,19 @@ makeCall = (response, normalizedCall) ->
   catch err
     response.send err.message
 
-installAliasHandler = (robot, alias) ->
-  robot.respond alias.regexp, (response) ->
+installCustomCallHandler = (robot, customCall) ->
+  robot.respond customCall.regexp, (response) ->
     try
       # try to parse everything contained in the last matching group
       # last matching group, because user could specify an alias containing ()
       # || "" because matching group is null if no parameter is given
       params = paramParser.parse(response.match[response.match.length - 1] || "")
       normalizedCall = {
-        method: alias.methodSplit,
-        fqn: alias.methodFqn,
+        method: customCall.methodSplit,
+        fqn: customCall.methodFqn,
         parameters: params,
       }
-      makeCall response, normalizedCall
+      makeCall response, normalizedCall, customCall.defaultParameters
     catch err
       response.send "Cannot parse your call (line: #{err.location.start.line}, column: #{err.location.start.column}): #{err.message}"
 
@@ -78,8 +78,8 @@ module.exports = (robot) ->
     robot.commands.push "*#{robot.name} #{command}*"
 
   # Add listeners for custom aliases
-  for alias in configHelper.getAliases()
-    installAliasHandler(robot, alias)
+  for customCall in configHelper.getCustomCalls()
+    installCustomCallHandler(robot, customCall)
 
 
   # Adds a custom listener for dynamically calling grpc services
@@ -87,7 +87,7 @@ module.exports = (robot) ->
     try
       # try to parse everything contained in the matching group
       parsed = callParser.parse(response.match[1])
-      makeCall response, parsed
+      makeCall response, parsed, configHelper.getDefaultParameters(parsed.fqn)
     catch err
       response.send "Cannot parse your call (line: #{err.location.start.line}, column: #{err.location.start.column}): #{err.message}"
 


### PR DESCRIPTION
Seems to work for me ..

I used the following config for the xkcd service

```
procedure_options:
  - procedure: .xkcd.XkcdGrabber.getLatestUrl
    help: "Returns the latest xkcd comic"
    custom_calls:
      - alias: last
    allow_default_call: false
    allowed_users:
      - matthias
    response_templates:
      - "Hi *{{user.name}}* here is the latest comic for you: {{response.url}}"
      - "I'm not in the mood right now, {{user.name}}"
  - procedure: .xkcd.XkcdGrabber.getRandomUrl
    custom_calls:
      - alias: random
    allowed_users:
      - jomaguma
  - procedure: .xkcd.XkcdGrabber.getPreviousUrl
    custom_calls:
      - alias: prev
        help: "help for prev"
      - alias: two
        defaults:
          offset: 2
    defaults:
      offset: 1
  - procedure: .xkcd.XkcdGrabber.getNextUrl
    custom_calls:
      - alias: next

```